### PR TITLE
Fixed power factor definition

### DIFF
--- a/it.polito.elite.dog.drivers.modbus.threephaseelectricitymeter/src/it/polito/elite/dog/drivers/modbus/threephaseelectricitymeter/ModbusThreePhaseElectricityMeterDriverInstance.java
+++ b/it.polito.elite.dog.drivers.modbus.threephaseelectricitymeter/src/it/polito/elite/dog/drivers/modbus/threephaseelectricitymeter/ModbusThreePhaseElectricityMeterDriverInstance.java
@@ -508,7 +508,7 @@ public class ModbusThreePhaseElectricityMeterDriverInstance extends ModbusDriver
 		PowerFactorStateValue powerFactorStateValue = new PowerFactorStateValue();
 		powerFactorStateValue.setValue(DecimalMeasure.valueOf("0 " + Unit.ONE));
 		
-		this.currentState.setState(PowerFactorMeasurementState.class.getCanonicalName(),
+		this.currentState.setState(PowerFactorMeasurementState.class.getSimpleName(),
 				new PowerFactorMeasurementState(powerFactorStateValue));
 		// --------------------------------------------------------------------
 		


### PR DESCRIPTION
That error caused the power factor to be unread because of a class name mismatch: the PowerFactorMeasurementState class was referred to with its canonical name, rather then with its simple name.